### PR TITLE
Update slackclient

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  twitter-on-slack:
+  app:
     restart: always
     build: .
     env_file:

--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ def publish_new_statuses(
     previous_links = set()
 
     if channel_id is not None:
-        history = slack_client.channels_history(channel=channel_id, count=100)
+        history = slack_client.conversations_history(channel=channel_id, count=100)
         for message in history.get("messages"):
             previous_post = message.get("text")
             link = previous_post.split("|")[0].strip("<>")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 python-twitter==3.5
-slackclient==2.5.0
+slackclient==2.8.1


### PR DESCRIPTION
Slack is removing `channels.history` in February next year in favour of `conversations.history`, so the appropriate method has been updated
Additional: docker container was renamed to `app`